### PR TITLE
Fixed 'TypeError: expectedType.toLowerCase is not a function' error

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -389,7 +389,11 @@ function validateType(name, value, field, models, allowBlankTargets, disallowExt
             return createReturnObject(errors, name);
         }
     } else {
-        expectedType = expectedType.toLowerCase();
+        if (typeof expectedType === "string") {
+            expectedType = expectedType.toLowerCase();
+        } else {
+            return new Error("Schema property (" + name + ") has a non string 'type' field")
+        }
     }
 
     // Only attempt to validate an object if properties are defined in the model.

--- a/tests/testObjectValidation.js
+++ b/tests/testObjectValidation.js
@@ -39,4 +39,43 @@ module.exports.validationTests = {
 
         test.done();
     },
+    typeFieldWrongType: function(test) {
+        var data = {
+            "id": "1",
+            "testObject": {
+                "testObjectProperty": "testObjectString"
+            }
+        };
+
+        var model = {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "ID"
+                },
+                "testObject": {
+                    // type should be a string, not an object
+                    "type": {
+                        "type": "object"
+                    },
+                    "properties": {
+                        "testObjectProperty": {
+                            "type": "string",
+                            "description": "testObjectProperty Description"
+                        }
+                    },
+                    "description": "Testing Example"
+                }
+            }
+        };
+
+        var errors = validator.validate(data, model);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.equals(errors.errors[0].message, "Schema property (testObject) has a non string 'type' field")
+
+        test.done()
+    }
 };


### PR DESCRIPTION
Bug description:

If accidentally using a schema where one of the properties has a `type` which is not a string, validator throws `TypeError: expectedType.toLowerCase is not a function` error.

Example of such schema:
```
{
  "type": "object",
  "properties": {
    "id": {
      "type": "string",
      "description": "ID"
    },
    "testObject": {
      // type should be a string, not an object
      "type": {
        "type": "object"
      },
      "properties": {
        "testObjectProperty": {
          "type": "string",
          "description": "testObjectProperty Description"
        }
      },
      "description": "Testing Example"
    }
  }
}
```

This PR fixes such an error by providing specific error message for this type of situation